### PR TITLE
Support GET request

### DIFF
--- a/src/There4/Slim/Test/WebTestClient.php
+++ b/src/There4/Slim/Test/WebTestClient.php
@@ -33,13 +33,20 @@ class WebTestClient
         // Capture STDOUT
         ob_start();
 
-        // Prepare a mock environment
-        \Slim\Environment::mock(array_merge(array(
+        $options = array(
             'REQUEST_METHOD' => strtoupper($method),
             'PATH_INFO'      => $path,
             'SERVER_NAME'    => 'local.dev',
-            'slim.input'     => http_build_query($formVars)
-        ), $optionalHeaders));
+        );
+
+        if ($method === 'get') {
+            $options['QUERY_STRING'] = http_build_query($formVars);
+        } else {
+            $options['slim.input']   = http_build_query($formVars);
+        }
+
+        // Prepare a mock environment
+        \Slim\Environment::mock(array_merge($options, $optionalHeaders));
 
         // Establish some useful references to the slim app properties
         $this->request  = $this->app->request();


### PR DESCRIPTION
It seems that `WebTestClient` doesn't support GET request, so I changed it.

versions:
- php: PHP 5.4.30
- there4/slim-test-helpers: master
- [codeguy/Slim](https://github.com/codeguy/Slim): 2.4.3

I create this test case:

``` php
<?php

use Slim\Slim;
use There4\Slim\Test\WebTestCase;

class SampleTest extends WebTestCase
{
    /**
     * @inheritdoc
     */
    public function getSlimInstance()
    {
        $app = new Slim(array(
            'debug' => false,
        ));

        // GET /messages
        $app->get('/messages', function() use ($app) {
            $request = $app->request();
            $user_id = $request->get('user_id');

            echo 'user_id:' . $user_id;
        });

        // POST /messages
        $app->post('/messages', function() use ($app) {
            $request = $app->request();
            $message = $request->post('message');

            echo 'message:' . $message;
        });

        return $app;
    }

    /**
     * @test
     */
    public function testPost()
    {
        $this->client->post('/messages', [
            'message' => 'hogehoge',
        ]);
        $this->assertSame('message:hogehoge', $this->client->response->getBody());
    }

    /**
     * @test
     */
    public function testGet()
    {
        $this->client->get('/messages', [
            'user_id' => 1234,
        ]);
        $this->assertSame('user_id:1234', $this->client->response->getBody());
    }
}
```

And execute this test with phpunit.
#### Test Result

Before:

```
.F

Time: 79 ms, Memory: 6.75Mb

There was 1 failure:

1) SampleTest::testGet
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-user_id:1234
+user_id:
```

After:

```
..

Time: 75 ms, Memory: 6.75Mb

OK (2 tests, 2 assertions)
```
