### PR TITLE
Make WebTestCase abstract

### DIFF
--- a/src/There4/Slim/Test/WebTestCase.php
+++ b/src/There4/Slim/Test/WebTestCase.php
@@ -4,7 +4,7 @@ namespace There4\Slim\Test;
 
 use \Slim\Slim;
 
-class WebTestCase extends \PHPUnit_Framework_TestCase
+abstract class WebTestCase extends \PHPUnit_Framework_TestCase
 {
     protected $app;
     protected $client;


### PR DESCRIPTION
PHPUnit includes files automatically which are non-abstract and tries to run tests. Thus, in our specific case we get an error on the WebTestCase file saying that "not tests are defined in WEbTestCase".

This commit should solve that issue.