### PR TITLE
Update to support current stable version of slim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "there4/slim-test-helpers",
+    "name": "justinph/slim-test-helpers",
     "description": "Integration testing helpers for the Slim Framework",
     "keywords": ["slim"],
     "homepage": "https://github.com/there4/slim-test-helpers",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "justinph/slim-test-helpers",
+    "name": "there4/slim-test-helpers",
     "description": "Integration testing helpers for the Slim Framework",
     "keywords": ["slim"],
     "homepage": "https://github.com/there4/slim-test-helpers",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "slim/slim": "2.4.*",
+        "slim/slim": "2.6.*",
         "phpunit/phpunit": "4.*"
     },
     "require-dev": {


### PR DESCRIPTION
This is a very, very minor update that allows this package to support slim framework 2.6.*. I've been using it in my testing without issue compared to using 2.4. Submitted since I saw @beeare was asking for it in issue #13.