### PR TITLE
Fix #15 - allow to run multiple requests in the same test

### DIFF
--- a/src/There4/Slim/Test/NoCacheRouter.php
+++ b/src/There4/Slim/Test/NoCacheRouter.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace There4\Slim\Test;
+
+/**
+* This router acts as a middle man requesting flushing the underlying
+* matching route cache on every request.
+*/
+class NoCacheRouter extends \Slim\Router
+{
+    public function __construct($originalRouter)
+    {
+        parent::__construct();
+        $this->routes = $originalRouter->routes;
+        $this->namedRoutes = $originalRouter->namedRoutes;
+        $this->routeGroups = $originalRouter->routeGroups;
+    }
+
+    public function getMatchedRoutes($httpMethod, $resourceUri, $reload = false)
+    {
+        // Force a reload of all matched routes
+        return parent::getMatchedRoutes($httpMethod, $resourceUri, true);
+    }
+}

--- a/src/There4/Slim/Test/WebTestCase.php
+++ b/src/There4/Slim/Test/WebTestCase.php
@@ -21,10 +21,17 @@ class WebTestCase extends \PHPUnit_Framework_TestCase
     // will most likely override this for your own application.
     public function getSlimInstance()
     {
-        return new Slim(array(
+        $slim = new Slim(array(
             'version' => '0.0.0',
             'debug'   => false,
             'mode'    => 'testing'
         ));
+        // force to overwrite the App singleton, so that \Slim\Slim::getInstance()
+        // returns the correct instance.
+        $slim->setName('default');
+
+        // make sure we don't use a caching router
+        $slim->router = new NoCacheRouter($slim->router);
+        return $slim;
     }
 }

--- a/src/There4/Slim/Test/WebTestClient.php
+++ b/src/There4/Slim/Test/WebTestClient.php
@@ -53,6 +53,10 @@ class WebTestClient
 
         // Prepare a mock environment
         Slim\Environment::mock(array_merge($options, $optionalHeaders));
+        $env = Slim\Environment::getInstance();
+        $this->app->router = new NoCacheRouter($this->app->router);
+        $this->app->request = new Slim\Http\Request($env);
+        $this->app->response = new Slim\Http\Response();
 
         // Establish some useful references to the slim app properties
         $this->request  = $this->app->request();

--- a/tests/There4Test/Slim/Test/WebTestClientTest.php
+++ b/tests/There4Test/Slim/Test/WebTestClientTest.php
@@ -33,6 +33,22 @@ class WebTestClientTest extends \PHPUnit_Framework_TestCase
         $client->foo($this->getValidUri());
     }
 
+    public function testMultipleRequest()
+    {
+        $this->getSlimInstance()->get('/:id', function ($id) {
+            echo "$id";
+        });
+
+        $client = new WebTestClient($this->getSlimInstance());
+        $client->get('/12');
+        $this->assertSame(200, $client->response->status());
+        $this->assertSame('12', $client->response->body());
+
+        $client->get('/14');
+        $this->assertSame(200, $client->response->status());
+        $this->assertSame('14', $client->response->body());
+    }
+
     public function getValidRequests()
     {
         $methods = $this->getValidRequestMethods();


### PR DESCRIPTION
It turns out (at least in Slim 2.6) that the request (and the response)
are a singleton in the Slim app.
Thus even when mocking a new \Slim\Environment like the WebTestclient does,
you'll always get the previous request that points to the previous
environment (and thus the previous endpoint).

The idea is to create fresh request and response object on every client
call, and also override the matched route cache that is built into
the router.
