### PR TITLE
Add phpdoc type info to public variables

### DIFF
--- a/src/There4/Slim/Test/WebTestCase.php
+++ b/src/There4/Slim/Test/WebTestCase.php
@@ -6,7 +6,10 @@ use \Slim\Slim;
 
 class WebTestCase extends \PHPUnit_Framework_TestCase
 {
+    /** @var \Slim\Slim */
     protected $app;
+
+    /** @var WebTestClient */
     protected $client;
 
     // Run for each unit test to setup our slim app environment

--- a/src/There4/Slim/Test/WebTestClient.php
+++ b/src/There4/Slim/Test/WebTestClient.php
@@ -6,8 +6,13 @@ use \Slim;
 
 class WebTestClient
 {
+    /** @var \Slim\Slim */
     public $app;
+
+    /** @var  \Slim\Http\Request */
     public $request;
+
+    /** @var  \Slim\Http\Response */
     public $response;
 
     // We support these methods for testing. These are available via


### PR DESCRIPTION
Helps IDEs discover the types, helping new Slim-framework users (such as myself) writing tests.