### PR TITLE
Allow OPTIONS method to be tested

### DIFF
--- a/src/There4/Slim/Test/WebTestClient.php
+++ b/src/There4/Slim/Test/WebTestClient.php
@@ -55,6 +55,11 @@ class WebTestClient
         $this->request('head', $path, $data, $optionalHeaders);
     }
 
+    public function options($path, $data = array(), $optionalHeaders = array())
+    {
+        $this->request('options', $path, $data, $optionalHeaders);
+    }
+
     // Abstract way to make a request to SlimPHP, this allows us to mock the
     // slim environment
     private function request($method, $path, $data = array(), $optionalHeaders = array())

--- a/tests/There4Test/Slim/Test/WebTestClientTest.php
+++ b/tests/There4Test/Slim/Test/WebTestClientTest.php
@@ -77,7 +77,7 @@ class WebTestClientTest extends \PHPUnit_Framework_TestCase
 
     private function getValidRequestMethods()
     {
-        return array('get', 'post', 'patch', 'put', 'delete');
+        return array('get', 'post', 'patch', 'put', 'delete', 'options');
     }
 
     private function getValidUri()


### PR DESCRIPTION
When testing CORS, it is helpful to send an OPTIONS to the Slim App, but
this wasn't a supported method by the slim-test-helpers.