### PR TITLE
Namespace compatibility for PHPUnit 6/DBUnit 3

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,15 @@
 
 chdir(dirname(__DIR__));
 require 'vendor/autoload.php';
+
+// Backward compatibility for PHPUnit 4/5
+if (!class_exists('\PHPUnit\Framework\TestCase') &&
+    class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias('\PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
+}
+
+// Backward compatibility for DBUnit 2
+if (!class_exists('\PHPUnit\DbUnit\TestCase') &&
+    class_exists('\PHPUnit_Extensions_Database_TestCase')) {
+    class_alias('\PHPUnit_Extensions_Database_TestCase', 'PHPUnit\DbUnit\TestCase');
+}


### PR DESCRIPTION
The PHPUnit 6 and DBUnit 3 namespaces differ from previous versions. This adds class aliases for backward compatibility.