### PR TITLE
Support PHPUnit 6 & DBUnit 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     },
     "require": {
         "slim/slim": "~3.1",
-        "phpunit/phpunit": "^4.8|5.*",
-        "phpunit/dbunit": "2.*",
+        "phpunit/phpunit": "^4.8|5.*|6.*",
+        "phpunit/dbunit": "2.*|3.*",
         "illuminate/database": ">=4.0"
     },
     "require-dev": {

--- a/src/There4/Slim/Test/WebDbTestCase.php
+++ b/src/There4/Slim/Test/WebDbTestCase.php
@@ -2,7 +2,11 @@
 
 namespace There4\Slim\Test;
 
-class WebDbTestCase extends \PHPUnit_Extensions_Database_TestCase
+use PDO;
+use PHPUnit\DbUnit\TestCase;
+use PHPUnit\DbUnit\DataSet\QueryDataSet;
+
+class WebDbTestCase extends TestCase
 {
     /** @var \Slim\App */
     protected $app;
@@ -33,7 +37,7 @@ class WebDbTestCase extends \PHPUnit_Extensions_Database_TestCase
     public function getConnection()
     {
         if ($this->conn === null) {
-            $pdo = new \PDO('sqlite::memory:');
+            $pdo = new PDO('sqlite::memory:');
             $this->conn = $this->createDefaultDBConnection($pdo, ':memory:');
         }
         return $this->conn;
@@ -41,8 +45,8 @@ class WebDbTestCase extends \PHPUnit_Extensions_Database_TestCase
 
     public function getDataSet()
     {
-         return new \PHPUnit_Extensions_Database_DataSet_QueryDataSet(
-             $this->getConnection()
-         );
+        return new QueryDataSet(
+            $this->getConnection()
+        );
     }
 }

--- a/src/There4/Slim/Test/WebTestCase.php
+++ b/src/There4/Slim/Test/WebTestCase.php
@@ -2,7 +2,7 @@
 
 namespace There4\Slim\Test;
 
-class WebTestCase extends \PHPUnit_Framework_TestCase
+class WebTestCase extends \PHPUnit\Framework\TestCase
 {
     /** @var \Slim\App */
     protected $app;

--- a/tests/There4Test/Slim/Test/WebDbTestCaseTest.php
+++ b/tests/There4Test/Slim/Test/WebDbTestCaseTest.php
@@ -2,15 +2,16 @@
 
 namespace There4Test\Slim\Test;
 
+use PHPUnit\Framework\TestCase;
 use There4\Slim\Test\WebDbTestCase;
 
-class WebDbTestCaseTest extends \PHPUnit_Framework_TestCase
+class WebDbTestCaseTest extends TestCase
 {
     public function testExtendsDbUnit()
     {
         $testCase = new WebDbTestCase();
         self::assertInstanceOf(
-            '\PHPUnit_Extensions_Database_TestCase',
+            '\PHPUnit\DbUnit\TestCase',
             $testCase
         );
     }
@@ -46,10 +47,10 @@ class WebDbTestCaseTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDataset()
     {
-        $testCase        = new WebDbTestCase();
-        $actualDataSet   = get_class($testCase->getDataSet());
-        $expectedDataSet = 'PHPUnit_Extensions_Database_DataSet_QueryDataSet';
-
-        self::assertEquals($expectedDataSet, $actualDataSet);
+        $testCase = new WebDbTestCase();
+        self::assertInstanceOf(
+            '\PHPUnit\DbUnit\DataSet\QueryDataSet',
+            $testCase->getDataSet()
+        );
     }
 }

--- a/tests/There4Test/Slim/Test/WebTestCaseTest.php
+++ b/tests/There4Test/Slim/Test/WebTestCaseTest.php
@@ -2,9 +2,10 @@
 
 namespace There4Test\Slim\Test;
 
+use PHPUnit\Framework\TestCase;
 use There4\Slim\Test\WebTestCase;
 
-class WebTestCaseTest extends \PHPUnit_Framework_TestCase
+class WebTestCaseTest extends TestCase
 {
     public function testSetup()
     {

--- a/tests/There4Test/Slim/Test/WebTestClientTest.php
+++ b/tests/There4Test/Slim/Test/WebTestClientTest.php
@@ -2,11 +2,13 @@
 
 namespace There4Test\Slim\Test;
 
+use Exception;
+use PHPUnit\Framework\TestCase;
 use Slim\App;
 use There4\Slim\Test\WebTestCase;
 use There4\Slim\Test\WebTestClient;
 
-class WebTestClientTest extends \PHPUnit_Framework_TestCase
+class WebTestClientTest extends TestCase
 {
     /**
      * @var App
@@ -144,7 +146,7 @@ class WebTestClientTest extends \PHPUnit_Framework_TestCase
     public function testInternalError()
     {
         $this->getSlimInstance()->get('/internalerror', function ($request, $response, $args) {
-            throw new \Exception('Testing /internalerror.');
+            throw new Exception('Testing /internalerror.');
             return $response;
         });
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,5 +12,16 @@ if (!class_exists('\PHPUnit\Framework\TestCase') &&
 // Backward compatibility for DBUnit 2
 if (!class_exists('\PHPUnit\DbUnit\TestCase') &&
     class_exists('\PHPUnit_Extensions_Database_TestCase')) {
-    class_alias('\PHPUnit_Extensions_Database_TestCase', 'PHPUnit\DbUnit\TestCase');
+    class_alias(
+        '\PHPUnit_Extensions_Database_TestCase',
+        'PHPUnit\DbUnit\TestCase'
+    );
+}
+
+if (!class_exists('\PHPUnit\DbUnit\DataSet\QueryDataSet') &&
+    class_exists('\PHPUnit_Extensions_Database_DataSet_QueryDataSet')) {
+    class_alias(
+        '\PHPUnit_Extensions_Database_DataSet_QueryDataSet',
+        'PHPUnit\DbUnit\DataSet\QueryDataSet'
+    );
 }


### PR DESCRIPTION
Added proper namespacing for PHPUnit 6/DBUnit 3 and class aliases for backward compatibility for older versions of PHPUnit back to 4.3.